### PR TITLE
console.logをdebugに変更

### DIFF
--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -82,9 +82,9 @@ export default defineContentScript({
 
       // watch current time and update original time
       currentTimeObserver = new MutationObserver((mutationsList) => {
-        console.log(
+        debug(
           "🕒 [archived live video] currentTime mutation:",
-          mutationsList
+          mutationsList,
         );
         for (const mutation of mutationsList) {
           // When the time is updated, a node is added


### PR DESCRIPTION
## 概要
`src/entrypoints/content.ts` の `currentTimeObserver` 内で使用していた `console.log` を `debug` 関数に置き換えました。

## テスト結果
- `npm run compile` を実行しましたが、依存関係不足のため失敗しました。